### PR TITLE
add periodic security scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,81 @@
+# Security Monitoring Workflow
+#
+# This workflow performs security scanning using only the security-specific
+# reusable workflows, without building or publishing.
+#
+# Schedule: Runs daily at 2:00 AM UTC to catch newly disclosed vulnerabilities
+# Manual Trigger: Can be triggered via GitHub Actions UI or gh CLI
+#
+# Security Checks:
+# - Source code scanning: Semgrep (OWASP Top 10, security-audit, CI), npm audit
+# - Artifact scanning: Trivy on dist/ artifacts (requires prior build)
+#
+name: Security Monitoring
+
+on:
+  schedule:
+    # Run daily at 2:00 AM UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    # Allow manual triggering
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+  pull-requests: write
+
+jobs:
+  # Scan source code for security vulnerabilities
+  scan_source:
+    name: Scan Source Code
+    uses: tehw0lf/workflows/.github/workflows/security-scan-source.yml@main
+    permissions:
+      contents: write
+      security-events: write
+      actions: read
+      pull-requests: write
+    with:
+      tool: "npm"
+      semgrep_rules: "auto p/security-audit p/owasp-top-ten p/ci p/nodejs p/typescript"
+      npm_audit_omit_dev: true
+      npm_audit_severity_threshold: "high"
+
+  # Download artifacts from latest CI build
+  # Note: Reuses artifacts from the main CI workflow instead of rebuilding
+  download_artifacts:
+    name: Download Build Artifacts
+    runs-on: ubuntu-latest
+    needs: scan_source
+    if: always()
+
+    steps:
+      - name: Download latest dist artifacts from CI
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: build.yml
+          name: dist
+          path: dist/
+          if_no_artifact_found: warn
+
+      - name: Upload artifacts for scanning
+        if: hashFiles('dist/**/*') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  # Scan built artifacts for vulnerabilities
+  scan_artifacts:
+    name: Scan Artifacts
+    needs: download_artifacts
+    if: needs.download_artifacts.result == 'success'
+    uses: tehw0lf/workflows/.github/workflows/security-scan-artifacts.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    with:
+      tool: "npm"
+      artifact_path: "dist"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "color",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "color",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "color",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Adds a scheduled daily security scan workflow (npm audit + Semgrep) using the reusable `security-scan-source.yml` from `tehw0lf/workflows`
- Scans run daily at 2:00 AM UTC and on manual dispatch
- Artifact scanning via Trivy using build artifacts from the existing CI workflow

## Test plan
- [ ] Workflow triggers correctly on schedule and via `workflow_dispatch`
- [ ] `npm audit` and Semgrep scans complete without unexpected failures