### PR TITLE
fix(csp): add form-action and base-uri directives

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -23,7 +23,7 @@ http {
   server {
     listen 80;
 
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'none'; base-uri 'self';" always;
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "color",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "color",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "color",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Adds `form-action 'none'` and `base-uri 'self'` to the Content-Security-Policy header.

These directives have no `default-src` fallback — if omitted, they are completely unrestricted. ZAP flags this as finding [10055] "CSP: Failure to Define Directive with No Fallback".

- `form-action 'none'` — no form submissions allowed (no forms in this app)
- `base-uri 'self'` — prevents base tag injection attacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated Content Security Policy headers with new directives for connection source validation, form submission controls, and base URL origin restrictions to strengthen application security posture.

* **Chores**
  * Version updated to 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->