### PR TITLE
chore(zap): add ignore rules for accepted findings

### DIFF
--- a/.github/workflows/dast-scan.yml
+++ b/.github/workflows/dast-scan.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       target_url: "https://color.tehwolf.de"
       scan_type: "baseline"
+      rules_file: ".zap/rules.tsv"

--- a/.zap/rules.md
+++ b/.zap/rules.md
@@ -1,0 +1,12 @@
+# ZAP DAST Ignore Rules
+
+Rules suppressed in `.zap/rules.tsv` with justification:
+
+| Rule ID | Name | Reason |
+|---------|------|--------|
+| 10035 | Strict-Transport-Security Header Not Set | HSTS is configured in Cloudflare (SSL/TLS → Edge Certificates → HSTS). ZAP scans the HTTP→HTTPS redirect path and does not see the header Cloudflare injects on HTTPS responses. |
+| 10055 | CSP: style-src unsafe-inline / Missing Directives | `style-src unsafe-inline` is required by the framework (Angular/Svelte). `form-action` and `base-uri` are explicitly defined in the CSP — ZAP flags these as informational when `default-src` has no fallback for them. |
+| 10109 | Modern Web Application | Informational finding — ZAP detected a SPA/PWA. Not a vulnerability. |
+| 10015 | Re-examine Cache-control Directives | Informational finding about cache headers. Not a vulnerability. |
+| 10049 | Storable and Cacheable Content | Informational finding. Static assets are intentionally cacheable. |
+| 10096 | Timestamp Disclosure - Unix | Build timestamps embedded in JS bundles by the build tool. Not sensitive data. |

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,6 @@
+10035	IGNORE	HSTS not set — handled by Cloudflare at TLS termination, not nginx
+10055	IGNORE	CSP style-src unsafe-inline required by framework; form-action and base-uri are explicitly set
+10109	IGNORE	Modern Web Application — informational only, not a vulnerability
+10015	IGNORE	Cache-control directives — informational only, not a vulnerability
+10049	IGNORE	Storable and Cacheable Content — informational only, not a vulnerability
+10096	IGNORE	Timestamp Disclosure — build timestamps in JS bundles, not sensitive data


### PR DESCRIPTION
## Summary

Adds `.zap/rules.tsv` to suppress ZAP findings that are either false positives or accepted risks, and `.zap/rules.md` documenting the justification for each suppression.

See `.zap/rules.md` for full reasoning per rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow configuration to include rule suppression settings.

* **Documentation**
  * Added documentation for suppressed security findings, listing specific rule IDs with justifications for why each finding is marked as informational or ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->