### PR TITLE
chore(zap): add Retrieved from Cache to ignore rules

### DIFF
--- a/.zap/rules.md
+++ b/.zap/rules.md
@@ -10,3 +10,4 @@ Rules suppressed in `.zap/rules.tsv` with justification:
 | 10015 | Re-examine Cache-control Directives | Informational finding about cache headers. Not a vulnerability. |
 | 10049 | Storable and Cacheable Content | Informational finding. Static assets are intentionally cacheable. |
 | 10096 | Timestamp Disclosure - Unix | Build timestamps embedded in JS bundles by the build tool. Not sensitive data. |
+| 10050 | Retrieved from Cache | Cloudflare CDN caching behavior. Not a vulnerability. |

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -4,3 +4,4 @@
 10015	IGNORE	Cache-control directives — informational only, not a vulnerability
 10049	IGNORE	Storable and Cacheable Content — informational only, not a vulnerability
 10096	IGNORE	Timestamp Disclosure — build timestamps in JS bundles, not sensitive data
+10050	IGNORE	Retrieved from Cache — Cloudflare CDN caching behavior, not a vulnerability


### PR DESCRIPTION
Adds rule 10050 (Retrieved from Cache) to ZAP ignore rules — Cloudflare CDN caching behavior, not a vulnerability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow configuration to use a rules file for managing exceptions.
  * Added documentation for suppressed security findings and their justifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->