### PR TITLE
fix(nginx): add caching and allow framing from tehwolf.de

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM nginx:alpine-slim
 RUN apk upgrade --no-cache
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY security-headers.conf /etc/nginx/security-headers.conf
 COPY index.html /usr/share/nginx/html/index.html

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,8 +23,8 @@ http {
   server {
     listen 80;
 
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; form-action 'none'; base-uri 'self';" always;
-    add_header X-Frame-Options "DENY" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     add_header Cross-Origin-Embedder-Policy "require-corp" always;
@@ -36,6 +36,36 @@ http {
       root /usr/share/nginx/html;
       index index.html;
       try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(js|css)$ {
+      root /usr/share/nginx/html;
+      expires 1y;
+      add_header Cache-Control "public, immutable";
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+      add_header Cross-Origin-Embedder-Policy "require-corp" always;
+      add_header Cross-Origin-Opener-Policy "same-origin" always;
+      add_header Cross-Origin-Resource-Policy "same-origin" always;
+      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+      access_log off;
+    }
+
+    location ~* \.(?:woff2?|svg|ico|png|jpg|jpeg|gif|webp)$ {
+      root /usr/share/nginx/html;
+      expires 7d;
+      add_header Cache-Control "public";
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+      add_header Cross-Origin-Embedder-Policy "require-corp" always;
+      add_header Cross-Origin-Opener-Policy "same-origin" always;
+      add_header Cross-Origin-Resource-Policy "same-origin" always;
+      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+      access_log off;
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,14 +23,7 @@ http {
   server {
     listen 80;
 
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header Cross-Origin-Embedder-Policy "require-corp" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Resource-Policy "same-origin" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    include /etc/nginx/security-headers.conf;
 
     location / {
       root /usr/share/nginx/html;
@@ -42,14 +35,7 @@ http {
       root /usr/share/nginx/html;
       expires 1y;
       add_header Cache-Control "public, immutable";
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
-      add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header X-Content-Type-Options "nosniff" always;
-      add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-      add_header Cross-Origin-Embedder-Policy "require-corp" always;
-      add_header Cross-Origin-Opener-Policy "same-origin" always;
-      add_header Cross-Origin-Resource-Policy "same-origin" always;
-      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+      include /etc/nginx/security-headers.conf;
       access_log off;
     }
 
@@ -57,14 +43,7 @@ http {
       root /usr/share/nginx/html;
       expires 7d;
       add_header Cache-Control "public";
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
-      add_header X-Frame-Options "SAMEORIGIN" always;
-      add_header X-Content-Type-Options "nosniff" always;
-      add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-      add_header Cross-Origin-Embedder-Policy "require-corp" always;
-      add_header Cross-Origin-Opener-Policy "same-origin" always;
-      add_header Cross-Origin-Resource-Policy "same-origin" always;
-      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+      include /etc/nginx/security-headers.conf;
       access_log off;
     }
   }

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,0 +1,8 @@
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+add_header Cross-Origin-Embedder-Policy "require-corp" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary
- Add nginx caching location blocks: js/css with 1y immutable, assets with 7d
- Allow \`frame-ancestors 'self' https://tehwolf.de\` so previews work on tehwolf.de
- Change \`X-Frame-Options\` from \`DENY\` to \`SAMEORIGIN\`

## Test plan
- [ ] Static assets are served with Cache-Control immutable headers
- [ ] App is embeddable in tehwolf.de preview iframe
- [ ] No CSP errors in browser console