### PR TITLE
fix(csp): set CORP to cross-origin and COEP to credentialless for embedding

### DIFF
--- a/security-headers.conf
+++ b/security-headers.conf
@@ -2,7 +2,7 @@ add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-add_header Cross-Origin-Embedder-Policy "require-corp" always;
+add_header Cross-Origin-Embedder-Policy "credentialless" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
-add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Cross-Origin-Resource-Policy "cross-origin" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
## Summary
- Change `Cross-Origin-Resource-Policy` from `same-origin` to `cross-origin` so the app can be embedded cross-origin in tehwolf.de
- Change `Cross-Origin-Embedder-Policy` from `require-corp` to `credentialless` for consistency