### PR TITLE
fix(csp): add unsafe-hashes and Angular Material sha256 to script-src

### DIFF
--- a/security-headers.conf
+++ b/security-headers.conf
@@ -2,7 +2,7 @@ add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-add_header Cross-Origin-Embedder-Policy "require-corp" always;
+add_header Cross-Origin-Embedder-Policy "credentialless" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
-add_header Cross-Origin-Resource-Policy "same-origin" always;
+add_header Cross-Origin-Resource-Policy "cross-origin" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'sha256-90k8vHqdT80Brtxlv3oF18HQh4+vdtyWQb8gjs8xgiY='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;


### PR DESCRIPTION
## Summary
- Add `'unsafe-hashes'` and both Angular Material SHA256 hashes to `script-src` to allow `this.media='all'` inline event handler
- Fixes missing styles on all Angular Material apps