### PR TITLE
fix(csp): add missing third sha256 hash to script-src

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "color",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT"
 }

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,4 +1,4 @@
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'sha256-90k8vHqdT80Brtxlv3oF18HQh4+vdtyWQb8gjs8xgiY='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'sha256-90k8vHqdT80Brtxlv3oF18HQh4+vdtyWQb8gjs8xgiY=' 'sha256-ErAUsrmdc3mWGVonKs19SrSbt07mbCfVeqlpQe9q/vo='; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self' https://tehwolf.de; form-action 'none'; base-uri 'self';" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;


### PR DESCRIPTION
## Summary
- The third Angular Material inline script hash `sha256-ErAUsrmdc3mWGVonKs19SrSbt07mbCfVeqlpQe9q/vo=` was missing from `script-src`
- This caused a CSP violation blocking Angular Material styles on tehwolf.de when embedded

## Test plan
- [ ] Verify no CSP errors in browser console for color app after deploy
- [ ] Confirm Angular Material components render correctly when embedded on tehwolf.de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Fixes**
  * Strengthened browser security by updating the site’s content security policy.
* **Chores**
  * Bumped the package version to `1.0.5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->