### PR TITLE
ci(lighthouse): set score thresholds based on local audit

### DIFF
--- a/.github/workflows/lighthouse-scan.yml
+++ b/.github/workflows/lighthouse-scan.yml
@@ -14,3 +14,7 @@ jobs:
       issues: write
     with:
       target_url: "https://color.tehwolf.de"
+      min_performance: 95
+      min_accessibility: 90
+      min_best_practices: 90
+      min_seo: 80

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>color</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='50' fill='%238e8e8e'/></svg>" />
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "color",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "color",
-      "version": "1.0.4",
+      "version": "1.0.6",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "color",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Sets realistic Lighthouse score thresholds based on local `npx lighthouse` audit (perf 100, a11y 94, bp 96, seo 82)
- Thresholds with ~5 point buffer: perf≥95, a11y≥90, best-practices≥90, seo≥80
- Goal: tighten thresholds incrementally as scores improve toward 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser favicon for easier site recognition in tabs and bookmarks.
* **Chores**
  * Updated the app version to 1.0.6.
  * Strengthened page quality checks in automated scans with higher minimum Lighthouse thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->