### PR TITLE
fix(seo): add meta description, robots.txt and raise lighthouse thresholds

### DIFF
--- a/.github/workflows/lighthouse-scan.yml
+++ b/.github/workflows/lighthouse-scan.yml
@@ -15,6 +15,6 @@ jobs:
     with:
       target_url: "https://color.tehwolf.de"
       min_performance: 70
-      min_accessibility: 90
-      min_best_practices: 90
-      min_seo: 80
+      min_accessibility: 100
+      min_best_practices: 100
+      min_seo: 100

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,4 @@ RUN apk upgrade --no-cache
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY security-headers.conf /etc/nginx/security-headers.conf
 COPY index.html /usr/share/nginx/html/index.html
+COPY robots.txt /usr/share/nginx/html/robots.txt

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Color – instantly preview and convert any color format (HEX, RGB, CMYK) in your browser." />
     <title>color</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='50' fill='%238e8e8e'/></svg>" />
     <style>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## Summary
- Add `meta description` to `index.html`
- Add `robots.txt` + `COPY` in Dockerfile (SPA fallback was serving HTML at `/robots.txt`)
- Raise lighthouse thresholds: `min_accessibility` 90→100, `min_best_practices` 90→100, `min_seo` 80→100

## Test plan
- [ ] `/robots.txt` returns valid content (not HTML)
- [ ] Lighthouse CI runs green with new thresholds after deploy
- [ ] SEO score reaches 100%