### PR TITLE
fix(a11y): wrap content in main landmark element

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
     </style>
   </head>
   <body>
+    <main>
     <div id="overlay">
       <div id="val-hex">—</div>
       <div id="val-rgb">—</div>
@@ -154,5 +155,6 @@
         }
       });
     </script>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Wrap page content in `<main>` landmark element
- Fixes Lighthouse `landmark-one-main` audit (A11y score was 94%)

## Test plan
- [x] Manual verification