### PR TITLE
fix(ci): pin action SHAs in security-scan.yml to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Download latest dist artifacts from CI
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: build.yml
           name: dist
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload artifacts for scanning
         if: hashFiles('dist/**/*') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: dist/


### PR DESCRIPTION
## Summary
- Pins `dawidd6/action-download-artifact@v6` and `actions/upload-artifact@v4` to full commit SHAs in `security-scan.yml`, resolving the Semgrep `github-actions-mutable-action-tag` finding (mutable tags can be silently repointed by the action owner, enabling supply-chain attacks).

## Test plan
- [ ] CI passes (lint/test/build)
- [ ] Semgrep security scan no longer flags `github-actions-mutable-action-tag` for these two steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow to use fixed, pinned action versions for artifact upload and download, improving supply-chain stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->